### PR TITLE
Bugfix: user-defined custom marks can be passed to Blocks again

### DIFF
--- a/portabletext_html/types.py
+++ b/portabletext_html/types.py
@@ -53,9 +53,7 @@ class Block:
         To make handling of span `marks` simpler, we define marker_definitions as a dict, from which
         we can directly look up both annotation marks or decorator marks.
         """
-        marker_definitions = get_default_marker_definitions(self.markDefs)
-        marker_definitions.update(self.marker_definitions)
-        self.marker_definitions = marker_definitions
+        self.marker_definitions = self._add_custom_marker_definitions()
         self.marker_frequencies = self._compute_marker_frequencies()
 
     def _compute_marker_frequencies(self) -> dict[str, int]:
@@ -67,6 +65,16 @@ class Block:
                 else:
                     counts[mark] = 0
         return counts
+
+    def _add_custom_marker_definitions(self) -> dict[str, Type[MarkerDefinition]]:
+        marker_definitions = get_default_marker_definitions(self.markDefs)
+        marker_definitions.update(self.marker_definitions)
+        for definition in self.markDefs:
+            if definition['_type'] in self.marker_definitions:
+                marker = self.marker_definitions[definition['_type']]
+                marker_definitions[definition['_key']] = marker
+                del marker_definitions[definition['_type']]
+        return marker_definitions
 
     def get_node_siblings(self, node: Union[dict, Span]) -> Tuple[Optional[dict], Optional[dict]]:
         """Return the sibling nodes (prev, next) to the given node."""

--- a/tests/test_marker_definitions.py
+++ b/tests/test_marker_definitions.py
@@ -72,7 +72,7 @@ def test_custom_marker_definition():
             marker_definition = next((md for md in context.markDefs if md['_key'] == marker), None)
             condition = marker_definition.get('cloudCondition', '')
             if not condition:
-                style = "display: none"
+                style = 'display: none'
                 return f'<{cls.tag} style=\"{style}\">'
             else:
                 return super().render_prefix(span, marker, context)
@@ -81,7 +81,7 @@ def test_custom_marker_definition():
         {
             '_type': 'block',
             'children': [{'_key': 'a1ph4', '_type': 'span', 'marks': ['some_id'], 'text': 'Sanity'}],
-            'markDefs': [{"_key": "some_id", "_type": "contractConditional", "cloudCondition": False}],
+            'markDefs': [{'_key': 'some_id', '_type': 'contractConditional', 'cloudCondition': False}],
         },
         custom_marker_definitions={'contractConditional': ConditionalMarkerDefinition},
     )


### PR DESCRIPTION
When I was trying to create my own custom mark definition, I noticed
that the information from 'markDefs' property is not passed down to the renderer.
`get_default_marker_definitions` method graps the context only from the default_annotations
dictionary.
`add_custom_marker_definitions` solves the issue by using the same logic as
`get_default_marker_definitions`, but looping over user-defined annotations
(self.marker_definitions).