### PR TITLE
add render_text method for custom marker definition class.

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,11 @@ class ComicSansEmphasis(MarkerDefinition):
         return f'</{cls.tag}>'
 
     @classmethod
+    def render_text(cls, span: Span, marker: str, context: Block) -> str:
+        # custom rendering logic can be placed here
+        return str(span.text)
+
+    @classmethod
     def render(cls, span: Span, marker: str, context: Block) -> str:
         result = cls.render_prefix(span, marker, context)
         result += str(span.text)

--- a/portabletext_html/marker_definitions.py
+++ b/portabletext_html/marker_definitions.py
@@ -37,9 +37,14 @@ class MarkerDefinition:
     def render(cls: Type[MarkerDefinition], span: Span, marker: str, context: Block) -> str:
         """Render the marked span directly with prefix and suffix."""
         result = cls.render_prefix(span, marker, context)
-        result += str(span.text)
+        result += cls.render_text(span, marker, context)
         result += cls.render_suffix(span, marker, context)
         return result
+
+    @classmethod
+    def render_text(cls: Type[MarkerDefinition], span: Span, marker: str, context: Block) -> str:
+        """Render the content part for a marked span."""
+        return str(span.text)
 
 
 # Decorators

--- a/tests/test_marker_definitions.py
+++ b/tests/test_marker_definitions.py
@@ -1,3 +1,4 @@
+# pylint: skip-file
 from typing import Type
 
 from portabletext_html import PortableTextRenderer
@@ -18,6 +19,7 @@ def test_render_emphasis_marker_success():
     for text in sample_texts:
         node = Span(_type='span', text=text)
         block = Block(_type='block', children=[node.__dict__])
+        assert EmphasisMarkerDefinition.render_text(node, 'em', block) == f'{text}'
         assert EmphasisMarkerDefinition.render(node, 'em', block) == f'<em>{text}</em>'
 
 
@@ -25,6 +27,7 @@ def test_render_strong_marker_success():
     for text in sample_texts:
         node = Span(_type='span', text=text)
         block = Block(_type='block', children=[node.__dict__])
+        assert StrongMarkerDefinition.render_text(node, 'strong', block) == f'{text}'
         assert StrongMarkerDefinition.render(node, 'strong', block) == f'<strong>{text}</strong>'
 
 
@@ -32,6 +35,7 @@ def test_render_underline_marker_success():
     for text in sample_texts:
         node = Span(_type='span', text=text)
         block = Block(_type='block', children=[node.__dict__])
+        assert UnderlineMarkerDefinition.render_text(node, 'u', block) == f'{text}'
         assert (
             UnderlineMarkerDefinition.render(node, 'u', block)
             == f'<span style="text-decoration:underline;">{text}</span>'
@@ -42,6 +46,7 @@ def test_render_strikethrough_marker_success():
     for text in sample_texts:
         node = Span(_type='span', text=text)
         block = Block(_type='block', children=[node.__dict__])
+        assert StrikeThroughMarkerDefinition.render_text(node, 'strike', block) == f'{text}'
         assert StrikeThroughMarkerDefinition.render(node, 'strike', block) == f'<del>{text}</del>'
 
 
@@ -51,6 +56,7 @@ def test_render_link_marker_success():
         block = Block(
             _type='block', children=[node.__dict__], markDefs=[{'_type': 'link', '_key': 'linkId', 'href': text}]
         )
+        assert LinkMarkerDefinition.render_text(node, 'linkId', block) == f'{text}'
         assert LinkMarkerDefinition.render(node, 'linkId', block) == f'<a href="{text}">{text}</a>'
 
 


### PR DESCRIPTION
This method gives a library user more flexibility when using custom marks with complex logic (conditionals, dynamic content substitution).