### PR TITLE
bugfix: call custom mark render_text() on render

### DIFF
--- a/portabletext_html/renderer.py
+++ b/portabletext_html/renderer.py
@@ -150,7 +150,19 @@ class PortableTextRenderer:
             marker_callable = block.marker_definitions.get(mark, DefaultMarkerDefinition)()
             result += marker_callable.render_prefix(span, mark, block)
 
-        result += html.escape(span.text).replace('\n', '<br/>')
+        # to avoid rendering the text multiple times,
+        # only the first custom mark will be used
+        custom_mark_text_rendered = False
+        if sorted_marks:
+            for mark in sorted_marks:
+                if custom_mark_text_rendered or mark in prev_marks:
+                    continue
+                marker_callable = block.marker_definitions.get(mark, DefaultMarkerDefinition)()
+                result += marker_callable.render_text(span, mark, block)
+                custom_mark_text_rendered = True
+
+        if not custom_mark_text_rendered:
+            result += html.escape(span.text).replace('\n', '<br/>')
 
         for mark in reversed(sorted_marks):
             if mark in next_marks:

--- a/portabletext_html/types.py
+++ b/portabletext_html/types.py
@@ -73,7 +73,7 @@ class Block:
             if definition['_type'] in self.marker_definitions:
                 marker = self.marker_definitions[definition['_type']]
                 marker_definitions[definition['_key']] = marker
-                del marker_definitions[definition['_type']]
+                # del marker_definitions[definition['_type']]
         return marker_definitions
 
     def get_node_siblings(self, node: Union[dict, Span]) -> Tuple[Optional[dict], Optional[dict]]:

--- a/tests/test_marker_definitions.py
+++ b/tests/test_marker_definitions.py
@@ -83,8 +83,14 @@ def test_custom_marker_definition():
             else:
                 return super().render_prefix(span, marker, context)
 
+        @classmethod
+        def render_text(cls: Type[MarkerDefinition], span: Span, marker: str, context: Block) -> str:
+            marker_definition = next((md for md in context.markDefs if md['_key'] == marker), None)
+            condition = marker_definition.get('cloudCondition', '')
+            return span.text if not condition else ''
+
     renderer = PortableTextRenderer(
-        {
+        blocks={
             '_type': 'block',
             'children': [{'_key': 'a1ph4', '_type': 'span', 'marks': ['some_id'], 'text': 'Sanity'}],
             'markDefs': [{'_key': 'some_id', '_type': 'contractConditional', 'cloudCondition': False}],


### PR DESCRIPTION
This commit fixes _render_span method:
 - if any of a span's marks has overriden render_text() method from the base class, we call it.
   Note that if a span has multiple mark definitions with render_text() method, only the first
   one will be processed. This is done to avoid text duplication inside an HTML tag.
 - otherwise, we append span.text to the resulting HTML string