### PR TITLE
bugfix: fix _render_node's error handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/ambv/black
-    rev: 21.12b0
+    rev: 22.3.0
     hooks:
       - id: black
         args: [ "--quiet" ]
@@ -19,7 +19,7 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 4.0.1
     hooks:
       - id: flake8
         additional_dependencies: [
@@ -33,6 +33,9 @@ repos:
             'flake8-annotations',
             'flake8-printf-formatting',
             'flake8-type-checking',
+        ]
+        args: [
+          '--allow-star-arg-any'
         ]
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.31.0

--- a/portabletext_html/renderer.py
+++ b/portabletext_html/renderer.py
@@ -113,7 +113,7 @@ class PortableTextRenderer:
             return self._custom_serializers.get(node.get('_type', ''))(node, context, list_item)  # type: ignore
 
         else:
-            if hasattr(node, '_type'):
+            if '_type' in node:
                 raise MissingSerializerError(
                     f'Found unhandled node type: {node["_type"]}. ' 'Most likely this requires a custom serializer.'
                 )

--- a/tests/fixtures/invalid_node.json
+++ b/tests/fixtures/invalid_node.json
@@ -1,0 +1,13 @@
+{
+  "_key": "73405dda68e7",
+  "children": [
+    {
+      "_key": "25a09c61d80a",
+      "_type": "span",
+      "marks": [],
+      "text": "Otovo guarantee is good"
+    }
+  ],
+  "markDefs": [],
+  "style": "normal"
+}

--- a/tests/fixtures/invalid_type.json
+++ b/tests/fixtures/invalid_type.json
@@ -1,0 +1,14 @@
+{
+  "_key": "73405dda68e7",
+  "_type": "invalid_type",
+  "children": [
+    {
+      "_key": "25a09c61d80a",
+      "_type": "span",
+      "marks": [],
+      "text": "Otovo guarantee is good"
+    }
+  ],
+  "markDefs": [],
+  "style": "normal"
+}

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -2,7 +2,9 @@ import html
 import json
 from pathlib import Path
 
-from portabletext_html.renderer import render
+import pytest
+
+from portabletext_html.renderer import MissingSerializerError, UnhandledNodeError, render
 
 
 def load_fixture(fixture_name) -> dict:
@@ -45,3 +47,15 @@ def test_nested_marks():
     fixture = load_fixture('nested_marks.json')
     output = render(fixture)
     assert output == '<p><strong>A word of <em>warning;</em></strong> Sanity is addictive.</p>'
+
+
+def test_missing_serializer():
+    fixture = load_fixture('invalid_type.json')
+    with pytest.raises(MissingSerializerError):
+        render(fixture)
+
+
+def test_invalid_node():
+    fixture = load_fixture('invalid_node.json')
+    with pytest.raises(UnhandledNodeError):
+        render(fixture)


### PR DESCRIPTION
A bug caused the MissingSerializerError to not be raised
when it was supposed to.

The change is in `portabletext_html/renderer.py` and I added two tests to confirm that the logic works. The remaining changes are to pass the linting / flake stages. I upgraded Black in the process, and ignored a flake8 rule I am surprised passed earlier. Might be caused by me upgrading flake8.