### PR TITLE
bugfix: fix a bug where custom serializer blocks can fail if after a …

### DIFF
--- a/portabletext_html/renderer.py
+++ b/portabletext_html/renderer.py
@@ -66,7 +66,7 @@ class PortableTextRenderer:
 
             if list_nodes and not is_list(node):
                 tree = self._normalize_list_tree(list_nodes)
-                result += ''.join([self._render_node(n, Block(**node), list_item=True) for n in tree])
+                result += ''.join([self._render_node(n, list_item=True) for n in tree])
                 list_nodes = []  # reset list_nodes
 
             if is_list(node):


### PR DESCRIPTION
…list

This commit fixes a bug where the rendering of a node can fail
if it has fields not supported by Block and follows directly after
a list item.

The list item logic would pass in the first node after the list as context
and cast it to a Block. This fails if the node has fields not supported
by Block. Which is the case for custom serializer blocks.

The context is actually not used, and removing it solves the bug.